### PR TITLE
Fix automatic build for all operating system and uploading them on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [linux, windows]
+        platform: [linux, windows, mac]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Godot:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: felix-schindler/build-godot-action@v1.6.1
+        uses: felix-schindler/build-godot-action@v2.0.0
         if: github.event.pull_request.draft == false
         with:
           name: untitled-plant-game
@@ -39,6 +39,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         with:
           files: |
-            ${{ github.workspace }}/${{ steps.build.outputs.build }}/untitled-plant-game.app.zip
-            ${{ github.workspace }}/${{ steps.build.outputs.build }}/untitled-plant-game.exe
-            ${{ github.workspace }}/${{ steps.build.outputs.build }}/untitled-plant-game.x86_64
+            build/untitled-plant-game.app.zip
+            build/untitled-plant-game.exe
+            build/untitled-plant-game.x86_64

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -248,7 +248,7 @@ ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
 kill $(pgrep -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\")
 rm -rf \"{temp_dir}\""
 dotnet/include_scripts_content=false
-dotnet/include_debug_symbols=true
+dotnet/include_debug_symbols=false
 dotnet/embed_build_outputs=false
 
 [preset.1]


### PR DESCRIPTION
Closes #104, #107, #101

## What changed

* remove debug symbols from mac executable
* update the build-godot-action to v2
* instead of doing dynamic magic that barely works we now link directly to the `build/` directory

## What really changed

* most action happend here https://github.com/felix-schindler/build-godot-action/releases/tag/v2.0.0
* ...and was tested here https://github.com/felix-schindler/upg

Good thing that forks exist 😆