### PR TITLE
[Plugin][Change] Add plugin for quick log level settings. Change logger to only print above configured level

### DIFF
--- a/Common/Logger.cs
+++ b/Common/Logger.cs
@@ -3,18 +3,21 @@ using Godot;
 
 namespace untitledplantgame.Common;
 
-enum LogLevel
+public enum LogLevel
 {
-	Info, // Grey
 	Debug, // Blue
+	Info, // Grey
 	Warn, // Yellow
 	Error, // Red
 }
 
 public class Logger
 {
+	// Config Stuff
+	public const string LogLevelSetting = "untitled_plant_game/logging/log_level"; // TODO: Make private
+	private const LogLevel DefaultConsoleLogLevel = LogLevel.Info;
+
 	public static Action<string> MessageLogged;
-	
 	private readonly string _logFilePath;
 	private readonly string _name;
 
@@ -61,6 +64,11 @@ public class Logger
 		}
 		else
 		{
+			if (ConsoleLogLevelInSettings > level)
+			{
+				return;
+			}
+
 			// Write to (Godot) console
 			if (LogLevel.Warn == level)
 				GD.PushWarning(message);
@@ -98,5 +106,23 @@ public class Logger
 	public void Error(string message)
 	{
 		Log(LogLevel.Error, message);
+	}
+
+	// Get log level from project settings or default to Info
+	private LogLevel ConsoleLogLevelInSettings
+	{
+		get
+		{
+			if (ProjectSettings.HasSetting(LogLevelSetting))
+			{
+				var logLevelName = ProjectSettings.GetSetting(LogLevelSetting).AsString();
+				if (Enum.TryParse(logLevelName, out LogLevel logLevel))
+				{
+					return logLevel;
+				}
+			}
+
+			return DefaultConsoleLogLevel;
+		}
 	}
 }

--- a/addons/upg_utils/Components/LogLevelOptionButton.cs
+++ b/addons/upg_utils/Components/LogLevelOptionButton.cs
@@ -10,42 +10,41 @@ public partial class LogLevelOptionButton : OptionButton
 {
 	public override void _Ready()
 	{
-		VisibilityChanged += () =>
-		{
-			if (IsVisibleInTree()) OnVisible();
-		};
-
-		ItemSelected += index =>
-		{
-			if (index < 0) return;
-			var levels = Enum.GetValues<LogLevel>();
-			var level = levels.ElementAt((int) index);
-			Settings.Logging.SetLogLevel(level);
-		};
+		VisibilityChanged += OnVisibilityChanged;
+		ItemSelected += OnItemSelected;
+		ProjectSettings.SettingsChanged += UpdateItems;
+	}
+	
+	public override void _ExitTree()
+	{
+		VisibilityChanged -= OnVisibilityChanged;
+		ItemSelected -= OnItemSelected;
+		ProjectSettings.SettingsChanged -= UpdateItems;
 	}
 
-	private void OnVisible()
+	private void UpdateItems()
 	{
-		// Reload content
-		GD.Print("Reloading LogLevelOptionButton content.");
 		Clear();
 
-		var levels = Enum.GetValues<LogLevel>();
-		foreach (var level in levels)
-		{
-			AddItem(level.ToString());
-		}
+		// Add log levels
+		var levels = Enum.GetValues<LogLevel>().ToList();
+		levels.ForEach(l => AddItem(l.ToString()));
 
 		// Set current value
 		var logLevel = Settings.Logging.GetLogLevel();
-		if (logLevel.HasValue)
-		{
-			var index = levels.ToList().IndexOf(logLevel.Value);
-			Select(index);
-		}
-		else
-		{
-			Select(-1);
-		}
+		Select(logLevel.HasValue ? levels.IndexOf(logLevel.Value) : -1);
+	}
+
+	private void OnItemSelected(long index)
+	{
+		if (index < 0) return;
+		var levels = Enum.GetValues<LogLevel>();
+		var level = levels.ElementAt((int) index);
+		Settings.Logging.SetLogLevel(level);
+	}
+
+	private void OnVisibilityChanged()
+	{
+		if (IsVisibleInTree()) UpdateItems();
 	}
 }

--- a/addons/upg_utils/Components/LogLevelOptionButton.cs
+++ b/addons/upg_utils/Components/LogLevelOptionButton.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using Godot;
+using untitledplantgame.Common;
+
+namespace untitledplantgame.addons.upg_utils.Components;
+
+[Tool]
+public partial class LogLevelOptionButton : OptionButton
+{
+	public override void _Ready()
+	{
+		VisibilityChanged += () =>
+		{
+			if (IsVisibleInTree()) OnVisible();
+		};
+
+		ItemSelected += index =>
+		{
+			if (index < 0) return;
+			var levels = Enum.GetValues<LogLevel>();
+			var level = levels.ElementAt((int) index);
+			Settings.Logging.SetLogLevel(level);
+		};
+	}
+
+	private void OnVisible()
+	{
+		// Reload content
+		GD.Print("Reloading LogLevelOptionButton content.");
+		Clear();
+
+		var levels = Enum.GetValues<LogLevel>();
+		foreach (var level in levels)
+		{
+			AddItem(level.ToString());
+		}
+
+		// Set current value
+		var logLevel = Settings.Logging.GetLogLevel();
+		if (logLevel.HasValue)
+		{
+			var index = levels.ToList().IndexOf(logLevel.Value);
+			Select(index);
+		}
+		else
+		{
+			Select(-1);
+		}
+	}
+}

--- a/addons/upg_utils/LogLevelDropdown.tscn
+++ b/addons/upg_utils/LogLevelDropdown.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://b4m27xxkrab00"]
+
+[ext_resource type="Script" path="res://addons/upg_utils/Components/LogLevelOptionButton.cs" id="1_uhtje"]
+
+[node name="LogLevelDropdown" type="OptionButton"]
+offset_right = 32.0
+offset_bottom = 20.0
+tooltip_text = "Minimum log level. Logs lower than this level will not be printed in console. Default is probably LogLevel.Info"
+script = ExtResource("1_uhtje")

--- a/addons/upg_utils/MainPanel.tscn
+++ b/addons/upg_utils/MainPanel.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=3 format=3 uid="uid://8yqa0e8vi8gj"]
+
+[ext_resource type="Script" path="res://addons/upg_utils/Components/LogLevelOptionButton.cs" id="1_aq1fw"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_jgwy2"]
+font_size = 24
+
+[node name="MainPanel" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="RichTextLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Developer Settings"
+label_settings = SubResource("LabelSettings_jgwy2")
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+columns = 2
+
+[node name="LogLevelLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+tooltip_text = "Logs below this log level will not be printed"
+mouse_filter = 1
+text = "Minimum Log Level"
+
+[node name="LogLevelOptionButton" type="OptionButton" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+selected = 1
+allow_reselect = true
+item_count = 4
+popup/item_0/text = "Debug"
+popup/item_1/text = "Info"
+popup/item_1/id = 1
+popup/item_2/text = "Warn"
+popup/item_2/id = 2
+popup/item_3/text = "Error"
+popup/item_3/id = 3
+script = ExtResource("1_aq1fw")

--- a/addons/upg_utils/Plugin.cs
+++ b/addons/upg_utils/Plugin.cs
@@ -1,54 +1,31 @@
 #if TOOLS
 using Godot;
 using System;
+using untitledplantgame.addons.upg_utils.Components;
 
 namespace untitledplantgame.addons.upg_utils;
 
 [Tool]
 public partial class Plugin : EditorPlugin
 {
-	public const string RootProjectSettingsPath = "plugins/untitledplantgame_utils";
-	
+	[Obsolete("Unused")]
 	private const string MainPanelPath = "res://addons/upg_utils/MainPanel.tscn";
+	private const string LogLevelDropdownPath = "res://addons/upg_utils/LogLevelDropdown.tscn";
+	private const CustomControlContainer LogLevelDropdownContainer = CustomControlContainer.Toolbar;
 
-	private Control _mainPanelInstance;
+	private Control _logLevelDropdown;
 
 	public override void _EnterTree()
 	{
-		var mainPanel = ResourceLoader.Load<PackedScene>(MainPanelPath);
-		_mainPanelInstance = (Control) mainPanel.Instantiate();
-		// Add the main panel to the editor's main viewport.
-		EditorInterface.Singleton.GetEditorMainScreen().AddChild(_mainPanelInstance);
-		// Hide the main panel. Very much required.
-		_MakeVisible(false);
+		// Log Level Thingy in toolbar
+		_logLevelDropdown = ResourceLoader.Load<PackedScene>(LogLevelDropdownPath).Instantiate<Control>();
+		AddControlToContainer(LogLevelDropdownContainer, _logLevelDropdown);
 	}
 
 	public override void _ExitTree()
 	{
-		if (IsInstanceValid(_mainPanelInstance))
-		{
-			_mainPanelInstance.QueueFree();
-		}
-	}
-
-	public override bool _HasMainScreen()
-	{
-		return true;
-	}
-
-	public override void _MakeVisible(bool visible)
-	{
-		if (IsInstanceValid(_mainPanelInstance))
-		{
-			_mainPanelInstance.Visible = visible;
-		}
-	}
-
-	public override string _GetPluginName() => "UntitledPlantGame";
-
-	public override Texture2D _GetPluginIcon()
-	{
-		return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
+		RemoveControlFromContainer(LogLevelDropdownContainer, _logLevelDropdown);
+		_logLevelDropdown.QueueFree();
 	}
 }
 #endif

--- a/addons/upg_utils/Plugin.cs
+++ b/addons/upg_utils/Plugin.cs
@@ -1,0 +1,54 @@
+#if TOOLS
+using Godot;
+using System;
+
+namespace untitledplantgame.addons.upg_utils;
+
+[Tool]
+public partial class Plugin : EditorPlugin
+{
+	public const string RootProjectSettingsPath = "plugins/untitledplantgame_utils";
+	
+	private const string MainPanelPath = "res://addons/upg_utils/MainPanel.tscn";
+
+	private Control _mainPanelInstance;
+
+	public override void _EnterTree()
+	{
+		var mainPanel = ResourceLoader.Load<PackedScene>(MainPanelPath);
+		_mainPanelInstance = (Control) mainPanel.Instantiate();
+		// Add the main panel to the editor's main viewport.
+		EditorInterface.Singleton.GetEditorMainScreen().AddChild(_mainPanelInstance);
+		// Hide the main panel. Very much required.
+		_MakeVisible(false);
+	}
+
+	public override void _ExitTree()
+	{
+		if (IsInstanceValid(_mainPanelInstance))
+		{
+			_mainPanelInstance.QueueFree();
+		}
+	}
+
+	public override bool _HasMainScreen()
+	{
+		return true;
+	}
+
+	public override void _MakeVisible(bool visible)
+	{
+		if (IsInstanceValid(_mainPanelInstance))
+		{
+			_mainPanelInstance.Visible = visible;
+		}
+	}
+
+	public override string _GetPluginName() => "UntitledPlantGame";
+
+	public override Texture2D _GetPluginIcon()
+	{
+		return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
+	}
+}
+#endif

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -10,6 +10,12 @@ public static class Settings
 	{
 		private const string LogLevelKey = Logger.LogLevelSetting;
 	
+		/// <summary>
+		/// Returns the current LogLevel defined in ProjectSettings. Returns null if nothing is defined.
+		/// 
+		/// This is a wrapper for ProjectSettings.GetSetting(...) that casts the value to the enum value.
+		/// </summary>
+		/// <returns></returns>
 		public static LogLevel? GetLogLevel()
 		{
 			if (!ProjectSettings.HasSetting(LogLevelKey))
@@ -26,6 +32,12 @@ public static class Settings
 			return null;
 		}
 	
+		/// <summary>
+		/// Sets the LogLevel in ProjectSettings.
+		///
+		/// This is a wrapper for ProjectSettings.SetSetting(...) that sets the value as a string.
+		/// </summary>
+		/// <param name="logLevel"></param>
 		public static void SetLogLevel(LogLevel logLevel)
 		{
 			ProjectSettings.SetSetting(LogLevelKey, logLevel.ToString());

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -29,7 +29,7 @@ public class Settings
 		public static void SetLogLevel(LogLevel logLevel)
 		{
 			ProjectSettings.SetSetting(LogLevelKey, logLevel.ToString());
-			GD.Print("Set log level to " + logLevel.ToString() + " in project settings.");
+			GD.Print($"Project Settings: Set log level to \"{logLevel.ToString()}\"");
 		}
 	}
 }

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Godot;
+using untitledplantgame.Common;
+
+namespace untitledplantgame.addons.upg_utils;
+
+public class Settings
+{
+	public class Logging
+	{
+		private const string LogLevelKey = Logger.LogLevelSetting;
+	
+		public static LogLevel? GetLogLevel()
+		{
+			if (!ProjectSettings.HasSetting(LogLevelKey))
+			{
+				return null;
+			}
+
+			var logLevelName = ProjectSettings.GetSetting(LogLevelKey).AsString();
+			if (Enum.TryParse(logLevelName, out LogLevel logLevel))
+			{
+				return logLevel;
+			}
+		
+			return null;
+		}
+	
+		public static void SetLogLevel(LogLevel logLevel)
+		{
+			ProjectSettings.SetSetting(LogLevelKey, logLevel.ToString());
+			GD.Print("Set log level to " + logLevel.ToString() + " in project settings.");
+		}
+	}
+}

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -29,7 +29,7 @@ public static class Settings
 		public static void SetLogLevel(LogLevel logLevel)
 		{
 			ProjectSettings.SetSetting(LogLevelKey, logLevel.ToString());
-			GD.Print($"Project Settings: Set log level to \"{logLevel.ToString()}\"");
+			GD.Print($"Set log level to \"{logLevel.ToString()}\"");
 		}
 	}
 }

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -29,7 +29,8 @@ public static class Settings
 		public static void SetLogLevel(LogLevel logLevel)
 		{
 			ProjectSettings.SetSetting(LogLevelKey, logLevel.ToString());
-			GD.Print($"Set log level to \"{logLevel.ToString()}\"");
+			ProjectSettings.Save();
+			GD.Print($"Set {LogLevelKey} to \"{logLevel.ToString()}\"");
 		}
 	}
 }

--- a/addons/upg_utils/Settings.cs
+++ b/addons/upg_utils/Settings.cs
@@ -4,9 +4,9 @@ using untitledplantgame.Common;
 
 namespace untitledplantgame.addons.upg_utils;
 
-public class Settings
+public static class Settings
 {
-	public class Logging
+	public static class Logging
 	{
 		private const string LogLevelKey = Logger.LogLevelSetting;
 	

--- a/addons/upg_utils/plugin.cfg
+++ b/addons/upg_utils/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="UPG Utilities"
+description="QoL for UPG devs"
+author=""
+version=""
+script="Plugin.cs"

--- a/project.godot
+++ b/project.godot
@@ -53,7 +53,7 @@ project/assembly_name="untitled-plant-game"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/resources_spreadsheet_view/plugin.cfg")
+enabled=PackedStringArray("res://addons/resources_spreadsheet_view/plugin.cfg", "res://addons/upg_utils/plugin.cfg")
 
 [global_group]
 


### PR DESCRIPTION
## What's new?
Adds a plugin "UPG Utilities" to the project.
It currently only has one feature to quickly edit the logging level. This feature is accessible via toolbar (top right corner)
![image](https://github.com/user-attachments/assets/88cef074-a4cd-4b5d-8d8a-a1dcf7f9f885)
The setting is saved in Godot's ProjectSettings and can be retrieved/set via `ProjectSettings` API or
`untitledplantgame.addons.upg_utils.Setttings.Logging`



## **Disclaimer**
Opening the project for the first time might throw an error. That is because Godot is trying to load a plugin that has not been compiled yet. Godot disables the plugin in that case. Simply build the project and re-enable the plugin.
> _This is not a **bug**. This is a **feature**_ ✨ 