### PR TITLE
[Feature/GUI] secondary press (WestButton/RMB) (for inventory)

### DIFF
--- a/Common/Inputs/GameActions/UINavigation.cs
+++ b/Common/Inputs/GameActions/UINavigation.cs
@@ -1,0 +1,7 @@
+﻿namespace untitledplantgame.Common.Inputs.GameActions;
+
+public class UINavigation
+{
+	public const string Accept = "ui_accept";
+	public const string SecondaryAccept = "base_west";
+}

--- a/Features/GUI/Book/Inventories/InventoryItemView.tscn
+++ b/Features/GUI/Book/Inventories/InventoryItemView.tscn
@@ -47,12 +47,13 @@ layout_mode = 2
 autowrap_mode = 3
 
 [node name="ItemQuantity" type="Label" parent="MarginContainer"]
-modulate = Color(1, 1, 1, 0.4)
+modulate = Color(1, 1, 1, 0.9)
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-theme_override_font_sizes/font_size = 16
+theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
+theme_override_constants/outline_size = 4
 text = "99"
 horizontal_alignment = 2
 vertical_alignment = 2

--- a/Features/GUI/Book/Inventories/InventoryView.cs
+++ b/Features/GUI/Book/Inventories/InventoryView.cs
@@ -13,6 +13,7 @@ namespace untitledplantgame.GUI.Book.Inventories;
 public partial class InventoryView : Control
 {
 	private readonly Dictionary<InventoryItemView, Action> _itemViewPressedActions = new();
+	private readonly Dictionary<InventoryItemView, Action> _itemViewSecondaryPressedActions = new();
 	[Export] private Container _inventoryItemViewContainer;
 	[Export] private PackedScene _inventoryItemViewPrefab;
 
@@ -53,7 +54,10 @@ public partial class InventoryView : Control
 			// Update actions
 			if (_itemViewPressedActions.ContainsKey(view))
 			{
+				// unbind LMB
 				view.Pressed -= _itemViewPressedActions[view];
+				// unbind RMB
+				view.SecondaryPressed -= _itemViewSecondaryPressedActions[view];
 			}
 
 			if (i >= items.Count)
@@ -65,15 +69,25 @@ public partial class InventoryView : Control
 
 			void PressedHandler()
 			{
-				_logger.Debug($"Handle click on {inventory.Name}[{snapshotIndex}/{i}]");
+				_logger.Debug($"Handle click on {inventory.Name}[{snapshotIndex}]");
 				if (CursorInventory.Instance.CanClick(inventory, snapshotIndex))
 				{
 					CursorInventory.Instance.HandleClick(inventory, snapshotIndex);
 				}
 			}
 
+			void SecondaryPressedHandler()
+			{
+				_logger.Debug($"Handle secondary click on {inventory.Name}[{snapshotIndex}]");
+				CursorInventory.Instance.HandleSecondary(inventory, snapshotIndex);
+			}
+
+			// Bind LMB
 			_itemViewPressedActions[view] = PressedHandler;
 			view.Pressed += PressedHandler;
+			// Bind RMB
+			_itemViewSecondaryPressedActions[view] = SecondaryPressedHandler;
+			view.SecondaryPressed += SecondaryPressedHandler;
 		}
 
 		// I dont know where to place this

--- a/Features/GUI/Components/ISeconaryPressable.cs
+++ b/Features/GUI/Components/ISeconaryPressable.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace untitledplantgame.GUI.Components;
+
+public interface ISeconaryPressable
+{
+	public event Action SecondaryPressed;
+}

--- a/Features/Inventory/BigInventory.cs
+++ b/Features/Inventory/BigInventory.cs
@@ -361,4 +361,34 @@ public class BigInventory : IInventory
 
 		return null;
 	}
+
+	public IItemStack RemoveItemFromSlot(int slotIdx, IItemStack item)
+	{
+		foreach (var inventory in _inventories.Values)
+		{
+			if (slotIdx < inventory.Size)
+			{
+				return inventory.RemoveItemFromSlot(slotIdx, item);
+			}
+
+			slotIdx -= inventory.Size;
+		}
+
+		return null;
+	}
+
+	public IItemStack PopItemFromSlot(int slotIdx, int amount)
+	{
+		foreach (var inventory in _inventories.Values)
+		{
+			if (slotIdx < inventory.Size)
+			{
+				return inventory.PopItemFromSlot(slotIdx, amount);
+			}
+
+			slotIdx -= inventory.Size;
+		}
+
+		return null;
+	}
 }

--- a/Features/Inventory/CursorInventory.cs
+++ b/Features/Inventory/CursorInventory.cs
@@ -130,13 +130,11 @@ public class CursorInventory : ICursorInventory
 	private IItemStack _content;
 	private readonly Logger _logger;
 	private IInventory _mostRecentInventoryPickup;
-	private int _pickupOriginIndex;
 
 	private CursorInventory()
 	{
 		_logger = new(GetType().Name);
 		_mostRecentInventoryPickup = null;
-		_pickupOriginIndex = -1;
 		_content = null;
 	}
 
@@ -296,7 +294,6 @@ public class CursorInventory : ICursorInventory
 
 		_content = item;
 		_mostRecentInventoryPickup = inventory;
-		_pickupOriginIndex = itemIndex;
 		ContentChanged?.Invoke();
 	}
 
@@ -372,17 +369,9 @@ public class CursorInventory : ICursorInventory
 			return;
 		}
 
-		if (_mostRecentInventoryPickup == null || _pickupOriginIndex < 0)
+		if (_mostRecentInventoryPickup == null)
 		{
 			_logger.Warn("No origin location saved to return item to");
-			ItemOrphaned?.Invoke(_content);
-		}
-
-		var destination = _mostRecentInventoryPickup?.GetItem(_pickupOriginIndex);
-
-		if (destination != null)
-		{
-			_logger.Error("Original space is occupied");
 			ItemOrphaned?.Invoke(_content);
 		}
 
@@ -390,8 +379,8 @@ public class CursorInventory : ICursorInventory
 
 		if (remainder != null && remainder.Count > 0)
 		{
-			// This might be the case with items that have special inventory restrictions
-			_logger.Error("Could not put item back to origin although destination is free. Unexpected Error");
+			// This might be the case with items that have special inventory restrictions or space was occupied somehow
+			_logger.Error("Could not put item back to origin although destination is free.");
 			ItemOrphaned?.Invoke(_content);
 		}
 
@@ -403,7 +392,6 @@ public class CursorInventory : ICursorInventory
 	{
 		_content = null;
 		_mostRecentInventoryPickup = null;
-		_pickupOriginIndex = -1;
 		ContentChanged?.Invoke();
 	}
 }

--- a/Features/Inventory/IInventory.cs
+++ b/Features/Inventory/IInventory.cs
@@ -265,5 +265,31 @@ public interface IInventory : IEnumerable<IItemStack>
 	/// <param name="item"></param>
 	/// <returns></returns>
 	IItemStack AddItemToSlot(int slotIdx, IItemStack item);
+
+	/// <summary>
+	///     Remove an item from the specified slot and returns the remaining stack that could not be deducted.
+	/// <para>
+	/// If the slot index is invalid, the item will not be removed and the item will be returned.
+	/// If the destination item stack is of different type, all items will be returned as well.
+	/// If the destination has less items than requested, all items will be returned as well.
+	/// </para>
+	/// </summary>
+	/// <param name="slotIdx"></param>
+	/// <param name="item"></param>
+	/// <returns></returns>
+	IItemStack RemoveItemFromSlot(int slotIdx, IItemStack item);
+	
+	/// <summary>
+	///     Pops a specified amount of an item from the specified slot and returns the popped item stack.
+	/// <para>
+	/// If the slot index is invalid, the item will not be removed and null will be returned.
+	/// If the destination item stack is of different type, null will be returned as well.
+	/// If the destination has fewer items than requested, null will be returned as well.
+	/// </para>
+	/// </summary>
+	/// <param name="slotIdx"></param>
+	/// <param name="amount"></param>
+	/// <returns></returns>
+	IItemStack PopItemFromSlot(int slotIdx, int amount);
 }
 // TODO: Replace javadoc @tags with c# xml variant

--- a/Features/Shops/RandomStockGenerator.cs
+++ b/Features/Shops/RandomStockGenerator.cs
@@ -12,7 +12,7 @@ namespace untitledplantgame.Shops;
 /// </summary>
 public class RandomStockGenerator
 {
-	private static readonly Random Rand = new(7);
+	private static readonly Random Rand = new(34);
 
 	/// <summary>
 	///     Generates random placeholder items. These do not exist in the game.
@@ -169,6 +169,7 @@ public class RandomStockGenerator
 		var items = ItemDatabase.Instance.ItemStacks
 			.OrderBy(o => Rand.Next())
 			.ToList<IItemStack>();
+		items.ForEach(it => it.Amount = Rand.Next(1, it.MaxStackSize));
 		return items.GetRange(0, Math.Min(items.Count, n));
 	}
 }

--- a/Features/TeleportPlayer/SceneTransition.tscn
+++ b/Features/TeleportPlayer/SceneTransition.tscn
@@ -46,6 +46,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("1_uv84e")
 
 [node name="ColorRect" type="ColorRect" parent="."]
@@ -55,6 +56,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 color = Color(0.235294, 0.235294, 0.235294, 0)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ColorRect"]


### PR DESCRIPTION
# What's new?

- Implements RMB/WestButton for inventory. Picks up a single item from a stack.
- Expand on `Clickable` class and connects that feature.
- Additional `add` and `remove` methods for `IInventory`.


**Other changes**:
- Fix Transition screen blocking all mouse input
- Improve visibility on quantity label on item
- Add random amount to random items
- Changed random seed in random items