### PR TITLE
[Bugfix] Fix player having to tap twice to re-open vending/seed

### DIFF
--- a/Features/Interaction/InteractionManager.cs
+++ b/Features/Interaction/InteractionManager.cs
@@ -16,10 +16,9 @@ namespace untitledplantgame.Interaction;
 public partial class InteractionManager : Node2D
 {
 	public static InteractionManager Instance { get; private set; }
-	
-	[Export]
-	private Label _label;
-	
+
+	[Export] private Label _label;
+
 	private int AreaCount => _activeAreas.Count;
 	private string BaseText => $"[{InputRemapper.GetButton(FreeRoam.Interact).ToString()}] ";
 	private bool _canInteract = true;
@@ -75,18 +74,15 @@ public partial class InteractionManager : Node2D
 
 	public void PerformInteraction()
 	{
-		if (Input.IsActionJustPressed(FreeRoam.Interact) && _canInteract)
+		if (!_canInteract || AreaCount <= 0)
 		{
-			if (AreaCount > 0)
-			{
-				_canInteract = false;
-				_label.Hide();
-
-				_activeAreas[0].Interact();
-
-				_canInteract = true;
-			}
+			return;
 		}
+
+		_canInteract = false;
+		_label.Hide();
+		_activeAreas[0].Interact();
+		_canInteract = true;
 	}
 
 	private int SortByDistanceToPlayer(IInteractable area1, IInteractable area2)
@@ -103,7 +99,6 @@ public partial class InteractionManager : Node2D
 			return int.MaxValue;
 		}
 
-		
 		float distance1 = _player.GlobalPosition.DistanceSquaredTo(area1.GetGlobalInteractablePosition());
 		float distance2 = _player.GlobalPosition.DistanceSquaredTo(area2.GetGlobalInteractablePosition());
 		GD.PrintRich(distance2);

--- a/Features/Player/Player.cs
+++ b/Features/Player/Player.cs
@@ -3,7 +3,6 @@ using Godot;
 using untitledplantgame.Common;
 using untitledplantgame.Common.GameStates;
 using untitledplantgame.Common.Inputs.GameActions;
-using untitledplantgame.Interaction;
 using untitledplantgame.Inventory;
 using untitledplantgame.Shops;
 using untitledplantgame.Tools;
@@ -13,7 +12,7 @@ namespace untitledplantgame.Player;
 public partial class Player : CharacterBody2D
 {
 	private readonly Logger _logger = new Logger("Player");
-	
+
 	// Input direction(?)
 	public Vector2 Direction = Vector2.Zero;
 
@@ -31,7 +30,7 @@ public partial class Player : CharacterBody2D
 	private PlayerStateMachine _stateMachine;
 	private BigInventory _inventory;
 
-	private Toolbelt _toolbelt = new (
+	private readonly Toolbelt _toolbelt = new(
 		new Tool[]
 		{
 			new Shears(12, 16),
@@ -44,22 +43,19 @@ public partial class Player : CharacterBody2D
 	public override void _Ready()
 	{
 		_logger.Info("! Ready !");
-		
+
 		Game.Instance.Provide(this);
-		
+
 		_stateMachine = GetNode<PlayerStateMachine>("StateMachine");
 		_animatedSprite2D = GetNode<AnimatedSprite2D>("AnimatedSprite2D");
 		_stateMachine.Initialize(this);
-		
+
 		EventBus.Instance.OnItemPickUp += OnItemPickUp;
 
 		// Initialize inventory
 		var rand = new RandomStockGenerator();
 		_inventory = new(20);
-		_inventory.InventoryChanged += () =>
-		{
-			EventBus.Instance.PlayerInventoryChanged(this, _inventory);
-		};
+		_inventory.InventoryChanged += () => { EventBus.Instance.PlayerInventoryChanged(this, _inventory); };
 		_inventory.AddItem(rand.GetRandomItems(12).ToArray());
 	}
 
@@ -70,7 +66,7 @@ public partial class Player : CharacterBody2D
 			_logger.Error("Item is null, cannot pick up.");
 			return;
 		}
-		
+
 		var leftovers = _inventory.AddItem(obj);
 		if (leftovers.Count > 0)
 		{
@@ -89,16 +85,12 @@ public partial class Player : CharacterBody2D
 		{
 			Direction = Vector2.Zero; // default value, movement is an exception
 		}
-
-		//Velocity = direction * MoveSpeed;
-		InteractionManager.Instance.PerformInteraction();
 	}
 
 	public void GetSetInputDirection()
 	{
 		Direction = Input.GetVector(FreeRoam.Left, FreeRoam.Right, FreeRoam.Up, FreeRoam.Down).Normalized();
 	}
-
 
 	public override void _PhysicsProcess(double delta)
 	{

--- a/Features/Player/StateIdle.cs
+++ b/Features/Player/StateIdle.cs
@@ -1,5 +1,6 @@
 using Godot;
 using untitledplantgame.Common.Inputs.GameActions;
+using untitledplantgame.Interaction;
 
 namespace untitledplantgame.Player;
 
@@ -45,6 +46,13 @@ public partial class StateIdle : State
 		{
 			return _useToolState;
 		}
+
+		//Velocity = direction * MoveSpeed;
+		if (inputEvent.IsActionPressed(FreeRoam.Interact))
+		{
+			InteractionManager.Instance.PerformInteraction();
+		}
+		
 		// Could be if-else's, or maybe not?
 		return null;
 	}

--- a/Features/Player/StateWalk.cs
+++ b/Features/Player/StateWalk.cs
@@ -1,5 +1,6 @@
 using Godot;
 using untitledplantgame.Common.Inputs.GameActions;
+using untitledplantgame.Interaction;
 
 namespace untitledplantgame.Player;
 
@@ -48,6 +49,12 @@ public partial class StateWalk : State
 		if (inputEvent.IsActionPressed(FreeRoam.UseTool))
 		{
 			return _useToolState;
+		}
+
+		//Velocity = direction * MoveSpeed;
+		if (inputEvent.IsActionPressed(FreeRoam.Interact))
+		{
+			InteractionManager.Instance.PerformInteraction();
 		}
 		// Could be if-else's, or maybe not?
 		return null;


### PR DESCRIPTION
# Bugfix

## Current Behaviour

Scenario 1

1. Tap A to interact with Seedboy or Vendingmachine.
2. Tap B to close the window.
3. Tap A again. Observe how nothing happens.
4. Tap A again. Menu opens again like 1.

Scenario 2
1. Press A (and do **not** release) to interact with seedboy or vending machine.
2. Tap B to close the window. (A still being held)
3. Release A.
4. Tap A to interact with seedboy or vending machine.

## Expected Behaviour

1. Tap A to interact
2. Tap B to close
3. Tap A to interact (again).

## Proposed changes

Avoid `Input.IsActionJustPressed` as it seems to not recognize PRESS events if the most recent press has not been released.
=> Use `@event.IsActionPressed()`.

`PerformInteraction` has no access to latest input event.
=> Move input handling and initial call to player states `HandleInput(event)`. This is where walking and use tool inputs are handled as well.

## Other changes
- Applied auto-format to files that had changes