### PR TITLE
[Hotfix] Make vending machine available via NPC again

### DIFF
--- a/Features/Dialogue/Events/OpenVendingMachine.cs
+++ b/Features/Dialogue/Events/OpenVendingMachine.cs
@@ -1,0 +1,25 @@
+﻿using Godot;
+using untitledplantgame.Common;
+using untitledplantgame.Dialogue.Models;
+using untitledplantgame.Vending;
+
+namespace untitledplantgame.Dialogue.Events;
+
+[GlobalClass]
+public partial class OpenVendingMachine : DialogueEvent
+{
+	private readonly Logger _logger = new(nameof(OpenVendingMachine));
+	private VendingMachine _vendingMachine;
+
+	public override void Execute()
+	{
+		if (_vendingMachine == null)
+		{
+			_logger.Info("VendingMachine is null. Creating new instance.");
+			_vendingMachine = new VendingMachine();
+		}
+
+		_logger.Debug("Triggering BeforeVendingMachineOpen event.");
+		EventBus.Instance.BeforeVendingMachineOpen(_vendingMachine);
+	}
+}

--- a/Resources/Dialogue/VendingMachine/VM_init_1.tres
+++ b/Resources/Dialogue/VendingMachine/VM_init_1.tres
@@ -1,9 +1,10 @@
-[gd_resource type="Resource" script_class="DialogueResourceObject" load_steps=9 format=3 uid="uid://djkgxlqpnhr00"]
+[gd_resource type="Resource" script_class="DialogueResourceObject" load_steps=12 format=3 uid="uid://djkgxlqpnhr00"]
 
 [ext_resource type="Script" path="res://Features/Dialogue/Models/DialogueResourceObject.cs" id="1_7b3gf"]
 [ext_resource type="Script" path="res://Features/Dialogue/Models/DialogueLine.cs" id="1_rx6l3"]
 [ext_resource type="Texture2D" uid="uid://bicv1fu7r5w4n" path="res://Assets/Characters/VMsan/vendingMachinePortrait.png" id="1_y4p5x"]
 [ext_resource type="Script" path="res://Features/Dialogue/Models/DialogueResponse.cs" id="2_aghnh"]
+[ext_resource type="Script" path="res://Features/Dialogue/Events/OpenVendingMachine.cs" id="3_eoli7"]
 
 [sub_resource type="Resource" id="Resource_i0uay"]
 script = ExtResource("1_rx6l3")
@@ -17,9 +18,21 @@ speakerName = "Vending Machine"
 DialogueExpression = ExtResource("1_y4p5x")
 dialogueText = "Do you want to sell?"
 
+[sub_resource type="Resource" id="Resource_2571g"]
+script = ExtResource("3_eoli7")
+speakerName = ""
+dialogueText = ""
+
+[sub_resource type="Resource" id="Resource_2jdte"]
+script = ExtResource("1_7b3gf")
+_dialogueId = ""
+_dialogueText = Array[Object]([SubResource("Resource_2571g")])
+_responses = null
+
 [sub_resource type="Resource" id="Resource_g0300"]
 script = ExtResource("2_aghnh")
 _responseButton = "Yes"
+_responseDialogue = SubResource("Resource_2jdte")
 
 [sub_resource type="Resource" id="Resource_yjfxv"]
 script = ExtResource("2_aghnh")


### PR DESCRIPTION
#287 disabled previous `NPC -> Dialogue` trigger, making vending machine inaccessible.
This adds the missing dialog event to trigger the vending machine gui.