### PR TITLE
[Hotfix] Fix related items missing in clone

### DIFF
--- a/Features/Inventory/IItemStack.cs
+++ b/Features/Inventory/IItemStack.cs
@@ -60,6 +60,8 @@ public interface IItemStack
 	// /// </summary>
 	// ReadOnlyCollection<IComponent> Components { get; }
 
+	Array<string> RelatedItemIds { get; }
+
 	/// <summary>
 	///     Gets the component of the specified type
 	/// </summary>
@@ -120,11 +122,11 @@ public interface IItemStack
 	{
 		if (!HasSameIdAndProps(that))
 		{
-			throw new System.ArgumentException("Cannot subtract different items");
+			throw new ArgumentException("Cannot subtract different items");
 		}
 		if (Amount < that.Amount)
 		{
-			throw new System.ArgumentException("Cannot subtract more than available");
+			throw new ArgumentException("Cannot subtract more than available");
 		}
 		var selfClone = Clone();
 		selfClone.Amount -= that.Amount;

--- a/Features/Inventory/ItemStack.cs
+++ b/Features/Inventory/ItemStack.cs
@@ -60,7 +60,7 @@ public partial class ItemStack : Resource, IItemStack
 		Id = id;
 	}
 	
-	public ItemStack(IItemStack item)
+	public ItemStack(IItemStack item) : this()
 	{
 		Id = item.Id;
 		Name = item.Name;
@@ -72,6 +72,7 @@ public partial class ItemStack : Resource, IItemStack
 		BaseValue = item.BaseValue;
 		Amount = item.Amount;
 		Components = item.Components.Duplicate(true); // I doubt this actually deep copies
+		RelatedItemIds = item.RelatedItemIds.Duplicate(true);
 	}
 
 	public T GetComponent<T>()
@@ -147,19 +148,7 @@ public partial class ItemStack : Resource, IItemStack
 
 	public IItemStack Clone()
 	{
-		return new ItemStack(Id)
-		{
-			Name = Name,
-			Icon = Icon,
-			ToolTipDescription = ToolTipDescription,
-			WikiDescription = WikiDescription,
-			Category = Category,
-			BaseValue = BaseValue,
-			MaxStackSize = MaxStackSize,
-			Amount = Amount,
-			// TODO: After the JSON fiasco I absolutely do NOT trust Godot to handle deep copies well (especially looking at the Stats)
-			Components = Components.Duplicate(true)
-		};
+		return new ItemStack(this);
 	}
 
 	public override string ToString()

--- a/Features/Item/Components/TagsComponent.cs
+++ b/Features/Item/Components/TagsComponent.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Godot.Collections;
 
 namespace untitledplantgame.Item.Components;
 
@@ -22,6 +22,10 @@ public partial class TagsComponent : AComponent, ICollection<TagsComponent.Tags>
 	{
 		_tags = new HashSet<Tags>(items);
 	}
+
+	public TagsComponent()
+	{
+	}
 	
 	public override TagsComponent Clone()
 	{
@@ -35,7 +39,7 @@ public partial class TagsComponent : AComponent, ICollection<TagsComponent.Tags>
 
 	public IEnumerator<Tags> GetEnumerator()
 	{
-		throw new System.NotImplementedException();
+		throw new NotImplementedException();
 	}
 
 	IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
Related items are missing when calling `clone()` on items. Encyclopedia relations are therefore empty (because they read from a copy from item database)