### PR TITLE
[Bugfix] Explicitely flag input as handled in dialogue

### DIFF
--- a/Features/Dialogue/DialogueUI.cs
+++ b/Features/Dialogue/DialogueUI.cs
@@ -47,7 +47,10 @@ public partial class DialogueUI : Control //Renaming keeps breaking Godot please
 	{
 		if (Input.IsActionJustPressed("ui_accept") && Visible)
 		{
-			OnPlayerInputConfirm();
+			if (OnPlayerInputConfirm())
+			{
+				GetViewport().SetInputAsHandled();
+			}
 		}
 	}
 
@@ -84,18 +87,19 @@ public partial class DialogueUI : Control //Renaming keeps breaking Godot please
 		ShowDialogueLine(_lineEnumerator.Current);
 	}
 
-	private void OnPlayerInputConfirm()
+	// Returns whether it has been handled
+	private bool OnPlayerInputConfirm()
 	{
 		if (_currentDialogue == null)
 		{
 			_logger.Warn("There is no dialogue to show."); //happens when player chooses a response TODO: ignore confirm response
-			return;
+			return false;
 		}
 
 		if (!_smashable)
 		{
 			_logger.Debug("Stop smashing the button.");
-			return;
+			return false;
 		}
 
 		_logger.Debug("Player input confirm.");
@@ -104,7 +108,7 @@ public partial class DialogueUI : Control //Renaming keeps breaking Godot please
 		{
 			_logger.Debug("Skipping animation.");
 			SkipAnimation();
-			return;
+			return true;
 		}
 
 		_smashable = true;
@@ -112,11 +116,12 @@ public partial class DialogueUI : Control //Renaming keeps breaking Godot please
 		{
 			_logger.Debug("Showing next line.");
 			ShowDialogueLine(_lineEnumerator.Current);
-			return;
+			return true;
 		}
 
 		_logger.Debug("End of dialogue block.");
 		OnEndOfDialogueBlock();
+		return true;
 	}
 
 	//Displays dialogue on the screen


### PR DESCRIPTION
# Change

Explicitely sets certain inputs as handled, so they do not propagate further.

# Notes

Closes #339 by stopping the "Confirm" input. It no longer reaches the seedshop UI and triggers the purchase.