### PR TITLE
Fix emoji missing in vending machine and disable slider/withdraw while item in hand

### DIFF
--- a/Features/GUI/Vending/VendingGUI.tscn
+++ b/Features/GUI/Vending/VendingGUI.tscn
@@ -320,7 +320,6 @@ anchor_right = 0.0
 anchor_bottom = 0.0
 
 [node name="EmoteBubble" parent="." instance=ExtResource("12_5lmun")]
-visible = false
 layout_mode = 1
 anchor_left = 0.31875
 anchor_top = 0.688889

--- a/Features/GUI/Vending/VendingMachineUI.cs
+++ b/Features/GUI/Vending/VendingMachineUI.cs
@@ -11,6 +11,7 @@ using untitledplantgame.Vending;
 
 namespace untitledplantgame.GUI.Vending;
 
+// EmoteBubble is automatically Show() on value changes. This may be unexpected if someone explicitely hides it in the scene. Oopsie.
 public partial class VendingMachineUI : Control
 {
 	[Export] private Node _itemStackContainer;

--- a/Features/GUI/Vending/VendingMachineUI.cs
+++ b/Features/GUI/Vending/VendingMachineUI.cs
@@ -64,6 +64,9 @@ public partial class VendingMachineUI : Control
 		}
 
 		_moneyLabel.Text = $"[center]{_vendingMachine.Gold}{BbImage.Coin}[/center]";
+
+		_slider.FocusMode = CursorInventory.Instance.Content == null ? FocusModeEnum.All : FocusModeEnum.None;
+		_withdrawButton.FocusMode = CursorInventory.Instance.Content == null ? FocusModeEnum.All : FocusModeEnum.None;
 	}
 
 	public override void _UnhandledInput(InputEvent @event)

--- a/Features/GUI/Vending/VendingMachineUI.cs
+++ b/Features/GUI/Vending/VendingMachineUI.cs
@@ -44,6 +44,7 @@ public partial class VendingMachineUI : Control
 		_emoteBubbleTimer.Timeout += OnEmoteBubbleTimeout;
 		AddChild(_emoteBubbleTimer);
 		_emoteBubble.FadeOut(0f);
+		_emoteBubble.Show();
 
 		_itemSlots = _itemStackContainer.GetChildren().Cast<VendingItemView>().ToList();
 		_slider.ValueChanged += OnSliderValueChanged;

--- a/Features/GUI/Vending/VendingMachineUI.cs
+++ b/Features/GUI/Vending/VendingMachineUI.cs
@@ -44,7 +44,7 @@ public partial class VendingMachineUI : Control
 		_emoteBubbleTimer.Timeout += OnEmoteBubbleTimeout;
 		AddChild(_emoteBubbleTimer);
 		_emoteBubble.FadeOut(0f);
-		_emoteBubble.Show();
+		
 
 		_itemSlots = _itemStackContainer.GetChildren().Cast<VendingItemView>().ToList();
 		_slider.ValueChanged += OnSliderValueChanged;
@@ -223,6 +223,7 @@ public partial class VendingMachineUI : Control
 		_vendingMachine.SetPriceSlider((float) value);
 
 		// NOTE: This does not correspond to the actual price or faith, but simply the slider position.
+		_emoteBubble.Show();
 		_emoteBubble.Value = (float) (_slider.Value / _slider.MaxValue);
 		_emoteBubbleTween?.Stop();
 		_emoteBubbleTween = _emoteBubble.FadeIn(_fadeInDuration);

--- a/Features/GUI/Vending/VendingMachineUI.cs
+++ b/Features/GUI/Vending/VendingMachineUI.cs
@@ -11,7 +11,7 @@ using untitledplantgame.Vending;
 
 namespace untitledplantgame.GUI.Vending;
 
-// EmoteBubble is automatically Show() on value changes. This may be unexpected if someone explicitely hides it in the scene. Oopsie.
+// EmoteBubble is automatically Show() on value changes. This may be unexpected if someone explicitly hides it in the scene. Oopsie.
 public partial class VendingMachineUI : Control
 {
 	[Export] private Node _itemStackContainer;


### PR DESCRIPTION
- re-enable emoji.
- Auto-Show() emoji on value change.
- Disable slider and withdraw button while item in hand